### PR TITLE
Here are some examples of the Remote Linux Lab

### DIFF
--- a/dotfiles/disable-colorpolicy.pkla
+++ b/dotfiles/disable-colorpolicy.pkla
@@ -1,0 +1,6 @@
+[Disable shutdown/whatever]
+Identity=unix-user:*
+Action=org.freedesktop.color-manager.create-device;org.freedesktop.color-manager.create-profile;org.freedesktop.color-manager.delete-device;org.freedesktop.color-manager.delete-profile;org.freedesktop.color-manager.device-inhibit;org.freedesktop.color-manager.install-system-wide;org.freedesktop.color-manager.modify-device;org.freedesktop.color-manager.modify-profile;org.freedesktop.color-manager.sensor-lock
+ResultAny=no
+ResultInactive=no
+ResultActive=no

--- a/dotfiles/disable-shutdown.pkla
+++ b/dotfiles/disable-shutdown.pkla
@@ -1,0 +1,6 @@
+[Disable shutdown]
+Identity=unix-user:*
+Action=org.freedesktop.consolekit.system.stop;org.freedesktop.consolekit.system.restart;org.freedesktop.upower.suspend;org.freedesktop.upower.hibernate
+ResultAny=no
+ResultInactive=no
+ResultActive=no

--- a/dotfiles/restrict-login-powermgmt.pkla
+++ b/dotfiles/restrict-login-powermgmt.pkla
@@ -1,0 +1,6 @@
+[Disable lightdm PowerMgmt]
+Identity=unix-user:*
+Action=org.freedesktop.login1.reboot;org.freedesktop.login1.reboot-multiple-sessions;org.freedesktop.login1.power-off;org.freedesktop.login1.power-off-multiple-sessions;org.freedesktop.login1.suspend;org.freedesktop.login1.suspend-multiple-sessions;org.freedesktop.login1.hibernate;org.freedesktop.login1.hibernate-multiple-sessions
+ResultAny=no
+ResultInactive=no
+ResultActive=no


### PR DESCRIPTION
These examples are of disabling power management for the Remote Linux Lab, since we don't want people powering off the server by accident.  The disable-colorpolicy is there to keep gnome3 from asking for a admin password or root when a user first logs in.  I would put more .dot files, but most of the time like for vim, if i need to see the line numbers I look at the bottom of the screen and if I really need to see them there's always :set number.
